### PR TITLE
code changes to mapObjectToArray

### DIFF
--- a/src/lecture-35/src/components/DynamicForm.jsx
+++ b/src/lecture-35/src/components/DynamicForm.jsx
@@ -49,7 +49,7 @@ const transformObject = (obj) => {
 };
 
 const mapObjectToArray = (obj) => {
-	return Object.keys(obj).map((key) => ({ name: key, value: '', ...obj[key] }));
+	return Object.keys(obj).map((key) => ({ name: key, ...obj[key] }));
 };
 
 const DynamicForm = () => {


### PR DESCRIPTION
The mapObjectToArray function has no need to return a value because, when it is called, it passes the argument named formState. FormState already has a value property.