### PR TITLE
Typo corrected 

### DIFF
--- a/class-overview/Lecture-37/README.md
+++ b/class-overview/Lecture-37/README.md
@@ -467,12 +467,12 @@ const tasks = [
 				icon: 'T',
 			},
 			{
-				id: 'tag-001',
+				id: 'tag-002',
 				text: 'Its done',
 				icon: 'T',
 			},
 			{
-				id: 'tag-001',
+				id: 'tag-003',
 				text: 'Its done',
 				icon: 'T',
 			},

--- a/src/lecture-37/todo-app/src/App.jsx
+++ b/src/lecture-37/todo-app/src/App.jsx
@@ -103,12 +103,12 @@ const tasks = [
 				icon: 'T',
 			},
 			{
-				id: 'tag-001',
+				id: 'tag-002',
 				text: 'Its done',
 				icon: 'T',
 			},
 			{
-				id: 'tag-001',
+				id: 'tag-003',
 				text: 'Its done',
 				icon: 'T',
 			},


### PR DESCRIPTION
class 37, 
Warning was: Encountered two children with the same key, `tag-001`. 
Keys should be unique so that components maintain their identity across updates. Non-unique keys may cause children to be duplicated and/or omitted — the behavior is unsupported and could change in a future version.