### PR TITLE
setData changed to setError

### DIFF
--- a/src/lecture-42/src/hooks/useFetchData.js
+++ b/src/lecture-42/src/hooks/useFetchData.js
@@ -23,7 +23,7 @@ const useFetchData = (url, cb) => {
 			setError('');
 		} catch (error) {
 			setLoading(false);
-			setData(error.message);
+			setError(error.message);
 		}
 	};
 


### PR DESCRIPTION
otherwise we got error "Uncaught TypeError: users.data?.map is not a function" when we intentionally set wrong URL for checking the catch{} block. 